### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
   changeset-check:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/muneebs/csrf-armor/security/code-scanning/3](https://github.com/muneebs/csrf-armor/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `changeset-check` job. Since the job only reads repository contents and does not perform any write operations, the minimal required permission is `contents: read`. This change ensures the job does not inherit unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to enhance security by restricting access to read-only for repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->