### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
   build-check:
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/muneebs/csrf-armor/security/code-scanning/2](https://github.com/muneebs/csrf-armor/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `build-check` job in the workflow file. This block should specify the least privileges required for the job to function correctly. Since the job only uploads build artifacts, it does not require write permissions beyond `contents: read`. 

The fix involves:
1. Adding a `permissions` block to the `build-check` job.
2. Setting `contents: read` as the permission level, which is sufficient for the job's operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions for improved security in the continuous integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->