### PR TITLE
Feat/jsr publish

### DIFF
--- a/.changeset/jsr-publishing-support.md
+++ b/.changeset/jsr-publishing-support.md
@@ -1,0 +1,23 @@
+---
+"@csrf-armor/core": minor
+"@csrf-armor/express": minor
+"@csrf-armor/nextjs": minor
+---
+
+Add JSR publishing support for dual npm/JSR distribution
+
+This change adds JSR (JavaScript Registry) publishing capability to enable distribution on both npm and JSR registries.
+Includes jsr.json configuration files for all packages and automated JSR publishing in the release workflow.
+
+**New Features:**
+
+- JSR configuration files (jsr.json) for all packages
+- JSR publishing scripts in package.json
+- Automated JSR publishing in GitHub release workflow
+- Updated release summaries with both npm and JSR installation commands
+
+**Benefits:**
+
+- Reach broader JavaScript ecosystem including Deno users
+- Maintain existing npm workflow while adding JSR support
+- Simplified dual-registry publishing process

--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -73,6 +73,10 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Publish to JSR
+        if: steps.changesets.outputs.published == 'true'
+        run: npx jsr publish
+
       - name: Create summary
         if: steps.changesets.outputs.published == 'true'
         run: |
@@ -81,8 +85,14 @@ jobs:
           echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "- **\(.name)@\(.version)**"' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Installation" >> $GITHUB_STEP_SUMMARY
+          echo "**NPM:**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "npm install \(.name)@\(.version)"' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**JSR:**" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "deno add \(.name)@\(.version)"' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Send Slack notification

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
+    "release:jsr": "pnpm build && pnpm publish:jsr",
+    "publish:jsr": "pnpm -r --filter='./packages/*' exec jsr publish",
     "security:check": "./scripts/security-check.sh",
     "security:secrets": "grep -r 'secret.*:' packages/*/src/ | grep -v 'process.env' | grep -v 'default-secret-change-this' || echo 'No hardcoded secrets found'",
     "security:timing": "grep -r '===' packages/*/src/ | grep -i 'token\\|secret\\|csrf' | grep -v 'timingSafeEqual' || echo 'No timing attack vulnerabilities found'",

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://jsr.io/schema/config-file.v1.json",
+  "name": "@csrf-armor/core",
+  "version": "1.0.3",
+  "exports": "./dist/index.js",
+  "include": [
+    "dist/",
+    "README.md"
+  ]
+}

--- a/packages/express/jsr.json
+++ b/packages/express/jsr.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://jsr.io/schema/config-file.v1.json",
+  "name": "@csrf-armor/express",
+  "version": "1.0.1",
+  "exports": "./dist/index.js",
+  "include": [
+    "dist/"
+  ]
+}

--- a/packages/nextjs/jsr.json
+++ b/packages/nextjs/jsr.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://jsr.io/schema/config-file.v1.json",
+  "name": "@csrf-armor/nextjs",
+  "version": "1.2.1",
+  "exports": {
+    ".": "./dist/index.js",
+    "./client": "./dist/client/index.js"
+  },
+  "include": [
+    "dist/",
+    "README.md"
+  ]
+}


### PR DESCRIPTION
Add JSR publishing support for dual npm/JSR distribution

This change adds JSR (JavaScript Registry) publishing capability to enable distribution on both npm and JSR registries.
Includes jsr.json configuration files for all packages and automated JSR publishing in the release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled publishing of packages to the JavaScript Registry (JSR) in addition to npm, allowing dual distribution.
  - Added JSR configuration and metadata to all packages.
  - Updated release workflow to automate publishing to both npm and JSR.
  - Enhanced release documentation with installation instructions for both npm and JSR.

- **Chores**
  - Added new scripts to streamline JSR publishing across all packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->