### PR TITLE
Potential fix for code scanning alert no. 17: Log injection

### DIFF
--- a/examples/express-app/app.js
+++ b/examples/express-app/app.js
@@ -165,7 +165,7 @@ app.use((err, req, res, next) => {
       ? String(err.message).replace(/[\n\r]/g, ' ')
       : 'Unknown error';
   const sanitizedPath = req.path
-      ? encodeURIComponent(String(req.path).replace(/[\n\r]/g, ' '))
+      ? encodeURIComponent(String(req.path).replace(/[\n\r]/g, '').replace(/[^a-zA-Z0-9-_]/g, encodeURIComponent))
       : 'Unknown path';
 
   if (err.code === 'CSRF_VERIFICATION_ERROR') {

--- a/examples/express-app/app.js
+++ b/examples/express-app/app.js
@@ -165,7 +165,7 @@ app.use((err, req, res, next) => {
       ? String(err.message).replace(/[\n\r]/g, ' ')
       : 'Unknown error';
   const sanitizedPath = req.path
-      ? encodeURIComponent(String(req.path).replace(/[\n\r]/g, '').replace(/[^a-zA-Z0-9-_]/g, encodeURIComponent))
+      ? encodeURIComponent(String(req.path).replace(/[\n\r]/g, '').replace(/[^a-zA-Z0-9_-]/g, ''))
       : 'Unknown path';
 
   if (err.code === 'CSRF_VERIFICATION_ERROR') {


### PR DESCRIPTION
Potential fix for [https://github.com/muneebs/csrf-armor/security/code-scanning/17](https://github.com/muneebs/csrf-armor/security/code-scanning/17)

To fix the issue, we will enhance the sanitization of `req.path` before logging it. Instead of relying solely on `encodeURIComponent` and newline removal, we will use a more comprehensive sanitization approach. Specifically, we will replace all non-alphanumeric characters with their encoded equivalents using `encodeURIComponent`. This ensures that no special characters can interfere with the log format.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sanitization of request paths in error messages for stricter and more secure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->