### PR TITLE
ci(codeql): bump setup-node to 22.x

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
The CodeQL workflow is failing because it builds the workspace on Node 20.x, but the workspace requires Node >=22 and the upgraded `tsdown` uses `Promise.withResolvers`.

Failed run:
```
Unsupported engine: wanted: {"node":">=22.0.0"} (current: {"node":"v20.20.2"…})
TypeError: Promise.withResolvers is not a function
```

This change bumps the CodeQL `actions/setup-node` step to `22.x` so the build succeeds before analysis runs.