### PR TITLE
fix(core): use path-segment-aware matching for excludePaths

### DIFF
--- a/.changeset/sec-val-2-excludepaths-matching.md
+++ b/.changeset/sec-val-2-excludepaths-matching.md
@@ -1,0 +1,13 @@
+---
+"@csrf-armor/core": patch
+---
+
+Fix excludePaths over-matching unrelated path prefixes
+
+`shouldSkipProtection` used `pathname.startsWith(path)` for exclusion
+matching, so `excludePaths: ['/api']` also matched `/api-public` and
+`/apiv2` — more paths than intended. Matching is now path-segment
+aware: `'/api'` matches `/api` and `/api/v1` but not `/api-public`.
+A trailing slash (`'/api/'`) matches children only, not the bare path.
+
+refs SEC-VAL-2

--- a/packages/core/docs/API.md
+++ b/packages/core/docs/API.md
@@ -254,8 +254,10 @@ interface CsrfConfig {
 
 ##### excludePaths
 
-- **Type**: `readonly string[]`
-- **Description**: Paths to exclude from CSRF protection
+- **Description**: Paths to exclude from CSRF protection. Matching is
+  path-segment aware: `'/api'` matches `/api` and `/api/v1` but not
+  `/api-public`. A trailing slash (`'/api/'`) matches children only
+  (`/api/v1`), not the bare `/api`.
 
 ##### skipContentTypes
 

--- a/packages/core/src/csrf.ts
+++ b/packages/core/src/csrf.ts
@@ -286,7 +286,13 @@ export class CsrfProtection<TRequest = unknown, TResponse = unknown> {
    */
   private shouldSkipProtection(request: CsrfRequest): boolean {
     const pathname = extractPathname(request.url);
-    if (this.config.excludePaths.some((path) => pathname.startsWith(path))) {
+    if (
+      this.config.excludePaths.some(
+        (path) =>
+          pathname === path ||
+          pathname.startsWith(path.endsWith('/') ? path : `${path}/`)
+      )
+    ) {
       return true;
     }
 

--- a/packages/core/tests/csrf.test.ts
+++ b/packages/core/tests/csrf.test.ts
@@ -243,6 +243,98 @@ describe('CsrfProtection – excludePaths', () => {
 });
 
 // ---------------------------------------------------------------------------
+// excludePaths – path-segment boundaries (SEC-VAL-2)
+// ---------------------------------------------------------------------------
+
+describe('CsrfProtection – excludePaths path-segment boundaries', () => {
+  it('AC-1: /api excludes /api (exact) and /api/v1 (child) but not /api-public or /apiv2', async () => {
+    const csrf = new CsrfProtection(new MockAdapter(), {
+      secret: TEST_SECRET,
+      strategy: 'double-submit',
+      excludePaths: ['/api'],
+    });
+
+    // exact match — skipped
+    let result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/api' }),
+      {}
+    );
+    expect(result.success).toBe(true);
+
+    // child — skipped
+    result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/api/v1' }),
+      {}
+    );
+    expect(result.success).toBe(true);
+
+    // unrelated prefix — NOT skipped
+    result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/api-public' }),
+      {}
+    );
+    expect(result.success).toBe(false);
+
+    // unrelated prefix — NOT skipped
+    result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/apiv2' }),
+      {}
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('AC-2: /api/ excludes /api/v1 (child) but not /api (bare)', async () => {
+    const csrf = new CsrfProtection(new MockAdapter(), {
+      secret: TEST_SECRET,
+      strategy: 'double-submit',
+      excludePaths: ['/api/'],
+    });
+
+    // child — skipped
+    let result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/api/v1' }),
+      {}
+    );
+    expect(result.success).toBe(true);
+
+    // bare path — NOT skipped (trailing slash = children only)
+    result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/api' }),
+      {}
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('AC-3: exact pathname match still works', async () => {
+    const csrf = new CsrfProtection(new MockAdapter(), {
+      secret: TEST_SECRET,
+      strategy: 'double-submit',
+      excludePaths: ['/health'],
+    });
+
+    const result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/health' }),
+      {}
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('AC-4: empty excludePaths excludes nothing', async () => {
+    const csrf = new CsrfProtection(new MockAdapter(), {
+      secret: TEST_SECRET,
+      strategy: 'double-submit',
+      excludePaths: [],
+    });
+
+    const result = await csrf.protect(
+      makeRequest({ method: 'POST', url: 'http://localhost/api/public' }),
+      {}
+    );
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // skipContentTypes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## SEC-VAL-2: excludePaths uses overly broad startsWith matching

### Problem

`shouldSkipProtection` in `packages/core/src/csrf.ts` used `pathname.startsWith(path)` for exclusion matching. A prefix like `/api` matched `/api`, `/api/v1`, `/api-public`, and `/apiv2` — more paths than intended.

### Fix

Replaced the prefix-only check with a path-segment-aware predicate:

```ts
pathname === path || pathname.startsWith(path.endsWith('/') ? path : `${path}/`)
```

- `/api` now matches `/api` (exact) and `/api/v1` (child), but **not** `/api-public` or `/apiv2`.
- `/api/` (trailing slash) matches children only (`/api/v1`), not the bare `/api`.
- Empty `excludePaths` excludes nothing.

### Acceptance criteria

1. `excludePaths: ['/api']` MUST match `/api` and `/api/v1`, but NOT `/api-public` or `/apiv2`.
2. `excludePaths: ['/api/']` MUST match `/api/v1` but NOT `/api`.
3. Exact pathname match still works.
4. Empty `excludePaths` excludes nothing.

### Verification

- `pnpm -r run build` — green (4 packages)
- `pnpm -r run test` — **207/207 tests pass** (core 97, express 30, nuxt 32, nextjs 48)
- `biome lint` — zero new issues (pre-existing diagnostics unrelated)
- QAS verdict: **APPROVED FOR RTE**

### Commits

| Commit | Description |
|--------|-------------|
| `03312a2` | `fix(core): use path-segment-aware matching for excludePaths` |
| `68ef67f` | `docs(core): document excludePaths matching semantics` |
| `8143d31` | `chore: add changeset for SEC-VAL-2 excludePaths fix` |

### Risk

`risk: low` — matching logic tightening. The change can only *reduce* what is excluded (more paths stay protected), never expand it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path matching for CSRF exclusion rules so similar prefixes no longer match by accident.
  * Exact paths and child paths are excluded as expected, while unrelated similarly named paths are not.
  * Trailing-slash patterns now apply only to descendant paths.
* **Documentation**
  * Clarified the behavior of CSRF exclusion path matching in the API docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->