### PR TITLE
fix(core): handle malformed Referer in validateOrigin

### DIFF
--- a/.changeset/sec-val-1-malformed-referer.md
+++ b/.changeset/sec-val-1-malformed-referer.md
@@ -1,0 +1,13 @@
+---
+"@csrf-armor/core": patch
+---
+
+Fix uncaught TypeError on malformed Referer header in validateOrigin
+
+`validateOrigin` called `new URL(referer).origin` without a try-catch.
+A malformed Referer header (e.g. `not-a-valid-url`) caused an unhandled
+TypeError that propagated as HTTP 500. Malformed Referer headers now
+return a validation failure (`isValid: false`, reason:
+`'Malformed Referer header'`) resulting in HTTP 403, not 500.
+
+refs SEC-VAL-1

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -64,7 +64,14 @@ export function validateOrigin(
     return { isValid: false, reason: 'Missing origin and referer headers' };
   }
 
-  const requestOrigin = origin ?? (referer ? new URL(referer).origin : null);
+  let requestOrigin: string | null = origin ?? null;
+  if (!requestOrigin && referer) {
+    try {
+      requestOrigin = new URL(referer).origin;
+    } catch {
+      return { isValid: false, reason: 'Malformed Referer header' };
+    }
+  }
 
   if (!requestOrigin) {
     return { isValid: false, reason: 'No origin or referer header' };

--- a/packages/core/tests/validation.test.ts
+++ b/packages/core/tests/validation.test.ts
@@ -101,12 +101,27 @@ describe('Validation', () => {
       const request: CsrfRequest = {
         method: 'POST',
         url: 'http://localhost/api',
-        headers: new Map([['referer', 'http://localhost/some/deep/path?query=1']]),
+        headers: new Map([
+          ['referer', 'http://localhost/some/deep/path?query=1'],
+        ]),
         cookies: new Map(),
       };
 
       const result = validateOrigin(request, TEST_CONFIG);
       expect(result.isValid).toBe(true);
+    });
+
+    it('should return invalid for a malformed Referer header, not throw', () => {
+      const request: CsrfRequest = {
+        method: 'POST',
+        url: 'http://localhost/api',
+        headers: new Map([['referer', 'not-a-valid-url']]),
+        cookies: new Map(),
+      };
+
+      const result = validateOrigin(request, TEST_CONFIG);
+      expect(result.isValid).toBe(false);
+      expect(result.reason).toBe('Malformed Referer header');
     });
   });
 


### PR DESCRIPTION
## SEC-VAL-1: Uncaught TypeError in validateOrigin on malformed Referer header

### Problem

`validateOrigin` in `packages/core/src/validation.ts` called `new URL(referer).origin` without a try-catch. A malformed Referer header (e.g. `not-a-valid-url`) caused an unhandled TypeError that propagated as HTTP 500.

### Fix

Wrapped `new URL(referer).origin` in a try-catch. On parse failure, returns `{ isValid: false, reason: 'Malformed Referer header' }` — a validation failure (403), not an unhandled exception (500).

Follows the existing try-catch-`new URL()` pattern already used in `extractPathname` (csrf.ts:40) and `validateSignedToken` (validation.ts:38).

### Acceptance criteria

1. Malformed Referer header returns HTTP 403 with validation-failure reason — not HTTP 500.
2. Valid Referer header continues to work unchanged.
3. No Referer and no Origin continues to return existing missing-headers validation failure.

### Commits

| Commit | Description |
|--------|-------------|
| `34b1e1a` | `fix(core): handle malformed Referer in validateOrigin` |
| `8345c83` | `chore: add changeset for SEC-VAL-1 malformed Referer fix` |

### Risk

`risk: low` — error handling tightening. Converts a 500 (crash) into a 403 (validation failure) — strictly more robust.