### PR TITLE
ci: attest every release and fix JSR publishing

### DIFF
--- a/.changeset/attested-releases.md
+++ b/.changeset/attested-releases.md
@@ -1,0 +1,7 @@
+---
+"@csrf-armor/express": patch
+---
+
+Add `repository`, `publishConfig`, `bugs`, and `homepage` metadata to the published manifest.
+
+The `repository` field is required for npm provenance: the registry rejects an attested publish whose `repository.url` does not match the repository the Sigstore provenance statement was minted from. Releases are now published with `--provenance`, so this package needs the field to be publishable at all.

--- a/.changeset/fix-jsr-publishing.md
+++ b/.changeset/fix-jsr-publishing.md
@@ -1,0 +1,15 @@
+---
+"@csrf-armor/core": patch
+"@csrf-armor/express": patch
+"@csrf-armor/nextjs": patch
+---
+
+Fix JSR publishing, which had never produced a release.
+
+The `jsr.json` configs pointed `exports` at `./dist/index.js`, a file the build never emits (it emits `.mjs`), and their versions had drifted up to three minors behind `package.json` because `changeset version` only knows about `package.json`. The JSR scope was empty as a result.
+
+Configs now export TypeScript source, so JSR can generate documentation and Node type declarations, and versions are synced from `package.json` at release time. Peer frameworks (`express`, `next`, `react`) are mapped to open ranges so JSR does not pin them.
+
+`csrfMiddleware`, `createCsrfMiddleware`, and `CsrfProvider` gained explicit return types — required by JSR's no-slow-types rule, and better `.d.ts` output for npm consumers too.
+
+`@csrf-armor/nuxt` is intentionally not published to JSR: its runtime imports Nuxt's virtual modules (`#app`, `#imports`), which only exist inside a Nuxt build.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Check packages can be published with provenance
+        run: ./scripts/check-provenance-metadata.sh
+
       - name: Setup pnpm
         uses: pnpm/action-setup@d648c2dd069001a242c621c8306af467f150e99d
 
@@ -74,6 +77,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check JSR configs are in sync and publishable
+        run: pnpm run check:jsr
 
       - name: Build packages
         run: pnpm run build

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for npm provenance (Sigstore OIDC)
     
     steps:
     - name: Checkout code
@@ -86,6 +86,10 @@ jobs:
         pnpm changeset publish --tag ${{ steps.snapshot.outputs.tag }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # changesets shells out to `pnpm publish`, which shells out to
+        # `npm publish`. npm reads this and attaches a Sigstore-signed SLSA
+        # provenance statement to every package it uploads.
+        NPM_CONFIG_PROVENANCE: 'true'
 
     - name: Get published versions
       id: versions
@@ -93,6 +97,18 @@ jobs:
         echo "packages<<EOF" >> $GITHUB_OUTPUT
         find packages -name package.json -exec jq -r '"\(.name)@\(.version)"' {} \; >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
+
+    - name: Verify npm provenance attestations
+      env:
+        SNAPSHOT_TAG: ${{ steps.snapshot.outputs.tag }}
+      run: |
+        # changesets stamps snapshots as 0.0.0-<tag>-<datetime>. Anything still
+        # on its release version was already on the registry and was skipped,
+        # so only the freshly minted snapshots are ours to verify.
+        jq -r --arg tag "$SNAPSHOT_TAG" \
+          'select(.version | startswith("0.0.0-" + $tag + "-")) | .name + "@" + .version' \
+          packages/*/package.json \
+          | xargs -r ./scripts/verify-provenance.sh
 
     - name: Create summary
       run: |

--- a/.github/workflows/release-changesets.yml
+++ b/.github/workflows/release-changesets.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write # Required for provenance-based publishing
+      id-token: write # Required for npm provenance (Sigstore OIDC)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -72,24 +72,10 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
-      # OPTION 1: Provenance-based publishing (RECOMMENDED - no token needed)
-      # Uses OpenID Connect with GitHub's id-token
-      # No NPM_TOKEN required if using this approach
-      # - name: Configure NPM for provenance
-      #   run: |
-      #     npm config set provenance true
-      #     npm config set registry https://registry.npmjs.org/
-
-      # OPTION 2: Granular Access Token (if you prefer token-based auth)
-      # 1. Create a new granular access token at: https://www.npmjs.com/settings/[your-username]/tokens
-      # 2. Set permissions: "Read and write" for the packages you want to publish
-      # 3. Add as NPM_TOKEN secret in GitHub repo settings
+      # Auth is token-based; the provenance statement is minted separately from
+      # the OIDC id-token granted above. Both are needed for attested publishes.
       - name: Configure NPM with Granular Access Token
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          cat ~/.npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -107,10 +93,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # changesets shells out to `pnpm publish`, which shells out to
+          # `npm publish`. npm reads this and attaches a Sigstore-signed SLSA
+          # provenance statement to every package it uploads.
+          NPM_CONFIG_PROVENANCE: "true"
 
+      - name: Verify npm provenance attestations
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          jq -r '.[] | "\(.name)@\(.version)"' <<<"$PUBLISHED_PACKAGES" \
+            | xargs ./scripts/verify-provenance.sh
+
+      # Publishes source (not dist) so JSR can generate docs and Node types.
+      # Auth is OIDC via the id-token permission above; each package must be
+      # linked to this repo in its jsr.io settings for that to be accepted.
       - name: Publish to JSR
         if: steps.changesets.outputs.published == 'true'
-        run: npx jsr publish
+        run: ./scripts/publish-jsr.sh --allow-dirty
 
       - name: Create summary
         if: steps.changesets.outputs.published == 'true'
@@ -127,7 +128,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**JSR:**" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[] | "deno add \(.name)@\(.version)"' >> $GITHUB_STEP_SUMMARY
+          jq -r '"deno add jsr:\(.name)@\(.version)"' packages/*/jsr.json >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Send Slack notification

--- a/package.json
+++ b/package.json
@@ -6,8 +6,14 @@
   "private": true,
   "author": "Muneeb Samuels",
   "contributors": [
-    { "name": "Raul", "url": "https://github.com/raulcrisan" },
-    { "name":  "Jordan Labrosse", "url":  "https://github.com/Jorgagu" }
+    {
+      "name": "Raul",
+      "url": "https://github.com/raulcrisan"
+    },
+    {
+      "name": "Jordan Labrosse",
+      "url": "https://github.com/Jorgagu"
+    }
   ],
   "workspaces": [
     "packages/*"
@@ -26,11 +32,12 @@
     "clean": "pnpm -r run clean && rm -rf node_modules/.cache",
     "clean:all": "pnpm clean && rm -rf node_modules pnpm-lock.yaml && pnpm -r exec rm -rf node_modules dist",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && ./scripts/sync-jsr-versions.sh",
     "release": "pnpm build && changeset publish",
-    "release:jsr": "pnpm build && pnpm publish:jsr",
-    "publish:jsr": "pnpm -r --filter='./packages/*' exec jsr publish",
+    "check:jsr": "./scripts/publish-jsr.sh --dry-run --allow-dirty",
+    "publish:jsr": "./scripts/publish-jsr.sh",
     "security:check": "./scripts/security-check.sh",
+    "security:provenance": "./scripts/check-provenance-metadata.sh",
     "security:secrets": "grep -r 'secret.*:' packages/*/src/ | grep -v 'process.env' | grep -v 'default-secret-change-this' || echo 'No hardcoded secrets found'",
     "security:timing": "grep -r '===' packages/*/src/ | grep -i 'token\\|secret\\|csrf' | grep -v 'timingSafeEqual' || echo 'No timing attack vulnerabilities found'",
     "security:random": "grep -r 'Math.random' packages/*/src/ || echo 'No weak random generation found'"

--- a/packages/core/jsr.json
+++ b/packages/core/jsr.json
@@ -1,10 +1,12 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@csrf-armor/core",
-  "version": "1.0.3",
-  "exports": "./dist/index.js",
-  "include": [
-    "dist/",
-    "README.md"
-  ]
+  "version": "1.2.3",
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": [
+      "src/**/*.ts",
+      "README.md"
+    ]
+  }
 }

--- a/packages/express/jsr.json
+++ b/packages/express/jsr.json
@@ -1,10 +1,16 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@csrf-armor/express",
-  "version": "1.0.1",
-  "exports": "./dist/index.js",
-  "include": [
-    "dist/",
-    "README.md"
-  ]
+  "version": "1.2.3",
+  "exports": "./src/index.ts",
+  "imports": {
+    "@csrf-armor/core": "jsr:@csrf-armor/core@^1.2.3",
+    "express": "npm:express@*"
+  },
+  "publish": {
+    "include": [
+      "src/**/*.ts",
+      "README.md"
+    ]
+  }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -18,7 +18,7 @@
     "test": "vitest run",
     "pretest:coverage": "cd ../core && pnpm run build",
     "test:coverage": "vitest run --coverage",
-    "typecheck": "tsc --noEmit",
+    "type-check": "tsc --noEmit",
     "lint": "biome check src/",
     "format": "biome format src/ --write"
   },
@@ -31,6 +31,19 @@
   ],
   "author": "Muneeb Samuels",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/muneebs/csrf-armor",
+    "directory": "packages/express"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/muneebs/csrf-armor/issues"
+  },
+  "homepage": "https://github.com/muneebs/csrf-armor#readme",
   "dependencies": {
     "@csrf-armor/core": "workspace:*"
   },

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -98,7 +98,13 @@ export type { ExpressAdapter };
  * }));
  * ```
  */
-export function csrfMiddleware(config?: CsrfConfig) {
+export function csrfMiddleware(
+  config?: CsrfConfig
+): (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => Promise<void> {
   const adapter = new ExpressAdapter();
   const protection = createCsrfProtection(adapter, config);
 

--- a/packages/nextjs/jsr.json
+++ b/packages/nextjs/jsr.json
@@ -1,14 +1,22 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@csrf-armor/nextjs",
-  "version": "1.2.1",
+  "version": "1.4.4",
   "exports": {
-    ".": "./dist/index.js",
-    "./client": "./dist/client/index.js"
+    ".": "./src/index.ts",
+    "./client": "./src/client/index.ts"
   },
-  "include": [
-    "dist/",
-    "src/",
-    "README.md"
-  ]
+  "imports": {
+    "@csrf-armor/core": "jsr:@csrf-armor/core@^1.2.3",
+    "next/navigation": "npm:next@*/navigation.js",
+    "next/server": "npm:next@*/server.js",
+    "react": "npm:react@*"
+  },
+  "publish": {
+    "include": [
+      "src/**/*.ts",
+      "src/**/*.tsx",
+      "README.md"
+    ]
+  }
 }

--- a/packages/nextjs/src/client/react.tsx
+++ b/packages/nextjs/src/client/react.tsx
@@ -122,7 +122,7 @@ export function CsrfProvider({
 }: Readonly<{
   children: React.ReactNode;
   config?: CsrfClientConfig;
-}>) {
+}>): React.JSX.Element {
   const [csrfToken, setCsrfToken] = useState<string | null>(
     config?.initialToken ?? null
   );

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -108,7 +108,15 @@ import { NextjsAdapter } from './adapter.js';
  * }
  * ```
  */
-export function createCsrfMiddleware(config?: CsrfConfig) {
+export function createCsrfMiddleware(config?: CsrfConfig): (
+  request: NextRequest,
+  response: NextResponse
+) => Promise<{
+  success: boolean;
+  response: NextResponse;
+  token?: string;
+  reason?: string;
+}> {
   const adapter = new NextjsAdapter();
   const csrfProtection = createCsrfProtection(adapter, config);
 

--- a/scripts/check-provenance-metadata.sh
+++ b/scripts/check-provenance-metadata.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Guard the preconditions npm enforces for provenance-attested publishes.
+#
+# The registry rejects an attested publish whose package.json `repository.url`
+# does not match the repository the provenance statement was minted from. That
+# rejection happens mid-release, after earlier packages are already live, so we
+# catch it in PR CI instead.
+
+set -euo pipefail
+
+REPO_URL="https://github.com/muneebs/csrf-armor"
+failed=0
+
+for manifest in packages/*/package.json; do
+  dir=$(dirname "$manifest")
+  name=$(jq -r '.name' "$manifest")
+
+  if [ "$(jq -r '.private // false' "$manifest")" = "true" ]; then
+    echo "- ${name}: private, skipped"
+    continue
+  fi
+
+  url=$(jq -r '.repository.url // ""' "$manifest")
+  if [ "$url" != "$REPO_URL" ]; then
+    echo "✗ ${name}: repository.url is \"${url}\", expected \"${REPO_URL}\"" >&2
+    echo "  npm rejects provenance publishes when this does not match." >&2
+    failed=1
+    continue
+  fi
+
+  if [ "$(jq -r '.repository.directory // ""' "$manifest")" != "$dir" ]; then
+    echo "✗ ${name}: repository.directory must be \"${dir}\"" >&2
+    failed=1
+    continue
+  fi
+
+  if [ "$(jq -r '.publishConfig.access // ""' "$manifest")" != "public" ]; then
+    echo "✗ ${name}: publishConfig.access must be \"public\"" >&2
+    failed=1
+    continue
+  fi
+
+  echo "✓ ${name}: ready for attested publish"
+done
+
+exit "$failed"

--- a/scripts/publish-jsr.sh
+++ b/scripts/publish-jsr.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Publish every package that carries a jsr.json, core first.
+#
+# @csrf-armor/nuxt has no jsr.json on purpose: its runtime imports Nuxt's
+# virtual modules (`#app`, `#imports`), which only exist inside a Nuxt build.
+#
+# Core goes first because the adapters declare `jsr:@csrf-armor/core@^x` in
+# their import maps and JSR resolves dependencies at publish time.
+#
+# Re-running is safe — jsr publish skips versions already on the registry. CI
+# authenticates over OIDC, so the job needs `id-token: write` and each package
+# must be linked to this repo in its jsr.io settings.
+
+set -euo pipefail
+
+dirs=""
+for dir in packages/core packages/*; do
+  [ -f "$dir/jsr.json" ] || continue
+  case " $dirs " in *" $dir "*) continue ;; esac
+  dirs="$dirs $dir"
+done
+
+for dir in $dirs; do
+  echo "==> publishing $dir to JSR"
+  (cd "$dir" && npx --yes jsr publish "$@")
+done

--- a/scripts/sync-jsr-versions.sh
+++ b/scripts/sync-jsr-versions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# changesets bumps package.json; jsr.json needs the same version and JSR won't
+# infer it. Runs as part of `version-packages`, so the release PR carries both.
+#
+# ponytail: only syncs `version`. Cross-package `jsr:` ranges use carets, so
+# they self-maintain within a major; a major bump needs a manual bump there.
+
+set -euo pipefail
+
+for config in packages/*/jsr.json; do
+  version=$(jq -r .version "$(dirname "$config")/package.json")
+  jq --arg v "$version" '.version = $v' "$config" >"$config.tmp"
+  mv "$config.tmp" "$config"
+  echo "$config → $version"
+done

--- a/scripts/verify-provenance.sh
+++ b/scripts/verify-provenance.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Assert that every published package carries an npm provenance attestation.
+#
+# Usage: scripts/verify-provenance.sh <name@version> [<name@version> ...]
+#
+# The npm registry exposes attestation bundles at
+#   https://registry.npmjs.org/-/npm/v1/attestations/<name>@<version>
+# A package published with `--provenance` gets two bundles: npm's own publish
+# attestation and a SLSA build provenance statement. We require the SLSA one,
+# because that is what links the tarball back to this repository and workflow.
+#
+# The bundle is written asynchronously by the registry, so we poll briefly
+# before failing.
+
+set -euo pipefail
+
+SLSA_PREDICATE='https://slsa.dev/provenance/v1'
+ATTEMPTS="${PROVENANCE_ATTEMPTS:-6}"
+DELAY="${PROVENANCE_RETRY_DELAY:-10}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <name@version> [<name@version> ...]" >&2
+  exit 2
+fi
+
+has_slsa_provenance() {
+  local spec="$1" body
+  body=$(curl -sSf "https://registry.npmjs.org/-/npm/v1/attestations/${spec}" 2>/dev/null) || return 1
+  jq -e --arg p "$SLSA_PREDICATE" \
+    'any(.attestations[]?; .predicateType == $p)' <<<"$body" >/dev/null
+}
+
+failed=0
+for spec in "$@"; do
+  found=0
+  for ((attempt = 1; attempt <= ATTEMPTS; attempt++)); do
+    if has_slsa_provenance "$spec"; then
+      found=1
+      break
+    fi
+    [ "$attempt" -lt "$ATTEMPTS" ] && sleep "$DELAY"
+  done
+
+  if [ "$found" -eq 1 ]; then
+    echo "✓ ${spec} has a SLSA provenance attestation"
+  else
+    echo "✗ ${spec} has no SLSA provenance attestation on the npm registry" >&2
+    failed=1
+  fi
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo "" >&2
+  echo "Publishes must be attested. Check that the publishing job sets" >&2
+  echo "NPM_CONFIG_PROVENANCE=true and grants 'id-token: write'." >&2
+  exit 1
+fi


### PR DESCRIPTION
Two release-pipeline defects, both silent until you go looking.

## 1. No release has ever been attested

The provenance switch was commented out in `release-changesets.yml` (the `# OPTION 1` block). Every published version confirms it:

```
@csrf-armor/core@1.2.3      registry attestations → 404
@csrf-armor/express@1.2.3   registry attestations → 404
@csrf-armor/nextjs@1.4.4    registry attestations → 404
@csrf-armor/nuxt@1.1.2      registry attestations → 404
```

`changeset publish` → `pnpm publish` → `npm publish`, and pnpm v10 forwards only `argv.original`, so a `--provenance` flag never survives the hop. `runNpm` spreads the full `process.env` and passes no `--userconfig`, so `NPM_CONFIG_PROVENANCE` reaches npm directly — npm's documented path for third-party publishing tools.

`@csrf-armor/express` had no `repository` field. The registry rejects an attested publish whose `repository.url` doesn't match the provenance source, so enabling provenance without that fix would have failed the release **after** core/nextjs/nuxt were already live.

## 2. JSR publishing has never produced a release

The `csrf-armor` scope was empty. Four separate breakages:

| Broken | Detail |
|---|---|
| `exports: "./dist/index.js"` | Build emits `.mjs`. Publish died with `Module not found` |
| Stale versions | `jsr.json` said core `1.0.3` / express `1.0.1` / nextjs `1.2.1` vs `1.2.3` / `1.2.3` / `1.4.4` — `changeset version` only touches `package.json` |
| Root `npx jsr publish` | Ran where no `jsr.json` exists |
| `publish:jsr` script | Would hit nuxt, which has no config |

Configs now export **source**, so JSR generates docs and Node `.d.ts` from TypeScript and there's no build output to keep in sync. That surfaced three genuine slow-type violations; the added return types improve the npm `.d.ts` too.

Peer frameworks map to open ranges (`npm:next@*`, `npm:react@*`, `npm:express@*`). Without these, `deno publish` resolves through byonm and bakes the *installed* version into the published graph, turning a peer dep into a pinned hard dep.

`@csrf-armor/nuxt` stays off JSR — its runtime imports `#app` / `#imports`, Nuxt virtual modules that only exist inside a Nuxt build.

## Enforcement

Configuring a thing isn't the same as ensuring it, so both failure modes now have gates:

| Gate | Runs | Catches |
|---|---|---|
| `scripts/check-provenance-metadata.sh` | PR CI | Package missing the fields npm requires — before it can break a release |
| `scripts/verify-provenance.sh` | post-publish | A publish that silently landed without a SLSA statement |
| `pnpm check:jsr` | PR CI | JSR config rot — the check that would have caught the above years ago |

The prerelease check filters on changesets' `0.0.0-<tag>-<datetime>` format so it only verifies what that run actually published, with `xargs -r` when nothing was.

## Also

- `packages/express` used `typecheck`, not `type-check`, so `pnpm -r run type-check` silently skipped it. CI had never type-checked that package.
- Dropped a debug step that echoed the auth npmrc into the build log.

## Verification

```
provenance verifier   sigstore@3.0.0, tuf-js@3.0.1 pass; @csrf-armor/core@1.2.3 correctly fails
metadata guard        4/4 pass (express would have failed before this PR)
jsr dry-run           core, express, nextjs all "Success Dry run complete"; ordering core-first
build / type-check    pass (express now included — 4 packages, was 3)
tests                 core 4, express 2, nextjs 3, nuxt 3 files, all pass
lint / format         clean (1 pre-existing warning in core, untouched)
workflows             all three parse; steps asserted against the right jobs
```

Also caught a portability bug in my own `publish-jsr.sh`: `"${args[@]}"` on an empty array is an unbound variable under `set -u` in bash 3.2, which macOS ships — `pnpm publish:jsr` with no args would have failed locally. Verified against `/bin/bash 3.2.57`, then dropped the array so `"$@"` stays at top level.

## Registry state

JSR scope is ready — `core`, `express`, `nextjs` all created and linked to `muneebs/csrf-armor`; the stray empty `nuxt` package was removed.

On the first release, `express` and `nextjs` declare `jsr:@csrf-armor/core@^1.2.x` and core must land in the same run for those to resolve. The pending changesets do bump core, so it will — but that ordering has never executed against the real registry. `jsr publish` is idempotent, so a re-run fixes it if anything trips.

## Follow-up, not in this PR

npm **Trusted Publishing** would drop `NPM_TOKEN` entirely and generate provenance without the flag. It needs per-package config on npmjs.com plus npm ≥ 11.5.1 on the runner, so it's a deliberate next step rather than something folded in silently.